### PR TITLE
error: remove failing code from microb integration

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,17 @@
+redefined = false
+
+exclude_files = {
+    '.rocks',
+}
+
+globals = {
+    'box'
+}
+
+ignore = {
+    '212', -- unused argument
+    '213', -- unused loop variable
+    '542', -- empty if branch
+}
+
+-- vim:syntax=lua:sw=4:ts=4:expandtab

--- a/cbench_runner.lua
+++ b/cbench_runner.lua
@@ -96,7 +96,7 @@ end
 function export(name, bench_key, value)
     local chart_name = name:gsub(' ', '_'):gsub('+_', ''):lower()
     local result = {
-        key = token, name = 'cb.' .. bench_key .. '.' .. chart_name,
+        name = 'cb.' .. bench_key .. '.' .. chart_name,
         param = tostring(math.floor(value)), unit = 'rps',
         tab = 'cbench.' .. chart_name, v = version
     }


### PR DESCRIPTION
In commit 51836e1fa6d5e040306bbe67ca28525450c8a863 the code responsible
for microb integration was removed, but not completely. This remainings
caused benchmark to exit with non-zero exit code, which is not good for
automation. The other unused code was also removed. I also added
.luacheckrc config that could have spotted the error before.