### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/cbench-scm-1.rockspec
+++ b/cbench-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'cbench'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/cbench.git';
+    url    = 'git+https://github.com/tarantool/cbench.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587