### PR TITLE
upgrade num to unsigned

### DIFF
--- a/bench-cfg.lua
+++ b/bench-cfg.lua
@@ -15,11 +15,9 @@ end
 local wal_mode = arg[2]
 
 box.cfg {
-    slab_alloc_arena    = 1,
+    memtx_memory        = 1024^3,
     pid_file            = "tarantool.pid",
     wal_mode            = wal_mode,
-    snap_dir = ".",
-    work_dir = "."
 }
 
 -- Tests to run

--- a/bench-cfg.lua
+++ b/bench-cfg.lua
@@ -2,7 +2,7 @@
 
 
 if #arg < 1 then
-    print('Please specify engine [memtex] or [vinyl]')
+    print('Please specify engine [memtx] or [vinyl]')
     os.exit(1)
 end
 local engine = arg[1]

--- a/bench-cfg.lua
+++ b/bench-cfg.lua
@@ -25,19 +25,19 @@ tests = {'replaces', 'selects', 'selrepl', 'updates', 'deletes'}
 -- Workloads
 workloads = {
     -- Run one extra test to warm up the server
-    {tests = tests, type = 'hash', parts = { 'num'}},
-    {tests = tests, type = 'hash', parts = { 'num' }},
+    {tests = tests, type = 'hash', parts = { 'unsigned'}},
+    {tests = tests, type = 'hash', parts = { 'unsigned' }},
     {tests = tests, type = 'hash', parts = { 'str' }},
 --[[
-    {tests = tests, type = 'hash', parts = { 'num', 'num' }},
-    {tests = tests, type = 'hash', parts = { 'num', 'str'}},
-    {tests = tests, type = 'hash', parts = { 'str', 'num' }},
+    {tests = tests, type = 'hash', parts = { 'unsigned', 'unsigned' }},
+    {tests = tests, type = 'hash', parts = { 'unsigned', 'str'}},
+    {tests = tests, type = 'hash', parts = { 'str', 'unsigned' }},
     {tests = tests, type = 'hash', parts = { 'str', 'str' }},
-    {tests = tests, type = 'tree', parts = { 'num' }},
+    {tests = tests, type = 'tree', parts = { 'unsigned' }},
     {tests = tests, type = 'tree', parts = { 'str' }},
-    {tests = tests, type = 'tree', parts = { 'num', 'num' }},
-    {tests = tests, type = 'tree', parts = { 'num', 'str' }},
-    {tests = tests, type = 'tree', parts = { 'str', 'num' }},
+    {tests = tests, type = 'tree', parts = { 'unsigned', 'unsigned' }},
+    {tests = tests, type = 'tree', parts = { 'unsigned', 'str' }},
+    {tests = tests, type = 'tree', parts = { 'str', 'unsigned' }},
     {tests = tests, type = 'tree', parts = { 'str', 'str' }}
 --]]
 }

--- a/cbench/bench.c
+++ b/cbench/bench.c
@@ -38,7 +38,7 @@ randstr(char *out, size_t len)
 /* {{{ Generators */
 
 char *
-gen_num(char *r, const struct keygen_params *params)
+gen_unsigned(char *r, const struct keygen_params *params)
 {
 	(void) params;
 	r = mp_encode_array(r, 1);
@@ -57,7 +57,7 @@ gen_str(char *r, const struct keygen_params *params)
 }
 
 char *
-gen_num_num(char *r, const struct keygen_params *params)
+gen_unsigned_unsigned(char *r, const struct keygen_params *params)
 {
 	(void) params;
 	r = mp_encode_array(r, 2);
@@ -79,7 +79,7 @@ gen_str_str(char *r, const struct keygen_params *params)
 }
 
 char *
-gen_num_str(char *r, const struct keygen_params *params)
+gen_unsigned_str(char *r, const struct keygen_params *params)
 {
 	char buf[params->len + 1];
 	r = mp_encode_array(r, 2);
@@ -90,7 +90,7 @@ gen_num_str(char *r, const struct keygen_params *params)
 }
 
 char *
-gen_str_num(char *r, const struct keygen_params *params)
+gen_str_unsigned(char *r, const struct keygen_params *params)
 {
 	char buf[params->len + 1];
 	r = mp_encode_array(r, 2);

--- a/cbench/bench.h
+++ b/cbench/bench.h
@@ -22,22 +22,22 @@ struct keygen_params {
 typedef char *(*keygen_t)(char *, const struct keygen_params *);
 
 API_EXPORT char *
-gen_num(char *r, const struct keygen_params *params);
+gen_unsigned(char *r, const struct keygen_params *params);
 
 API_EXPORT char *
 gen_str(char *r, const struct keygen_params *params);
 
 API_EXPORT char *
-gen_num_num(char *r, const struct keygen_params *params);
+gen_unsigned_unsigned(char *r, const struct keygen_params *params);
 
 API_EXPORT char *
 gen_str_str(char *r, const struct keygen_params *params);
 
 API_EXPORT char *
-gen_num_str(char *r, const struct keygen_params *params);
+gen_unsigned_str(char *r, const struct keygen_params *params);
 
 API_EXPORT char *
-gen_str_num(char *r, const struct keygen_params *params);
+gen_str_unsigned(char *r, const struct keygen_params *params);
 
 /* }}} */
 

--- a/cbench/init.lua
+++ b/cbench/init.lua
@@ -22,22 +22,22 @@ ffi.cdef([[
     typedef char *(*keygen_t)(char *, const struct keygen_params *);
 
     char *
-    gen_num(char *r, const struct keygen_params *params);
+    gen_unsigned(char *r, const struct keygen_params *params);
 
     char *
     gen_str(char *r, const struct keygen_params *params);
 
     char *
-    gen_num_num(char *r, const struct keygen_params *params);
+    gen_unsigned_unsigned(char *r, const struct keygen_params *params);
 
     char *
     gen_str_str(char *r, const struct keygen_params *params);
 
     char *
-    gen_num_str(char *r, const struct keygen_params *params);
+    gen_unsigned_str(char *r, const struct keygen_params *params);
 
     char *
-    gen_str_num(char *r, const struct keygen_params *params);
+    gen_str_unsigned(char *r, const struct keygen_params *params);
 
     /* }}} */
 

--- a/cbench_runner.lua
+++ b/cbench_runner.lua
@@ -23,11 +23,9 @@ elseif engine == 'memtx' then
 end
 
 box.cfg {
-    slab_alloc_arena = 1,
+    memtx_memory = 1024^3,
     pid_file = 'tarantool.pid',
     wal_mode = wal_mode,
-    snap_dir = '.',
-    work_dir = '.',
 }
 
 local bench = require('cbench')

--- a/cbench_runner.lua
+++ b/cbench_runner.lua
@@ -55,27 +55,27 @@ local tests = { 'replaces', 'selects', 'selrepl', 'updates', 'deletes' }
 local workloads
 if engine == 'vinyl' then
     workloads = {
-        { tests = tests, type = 'tree', parts = { 'num' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned' } },
         { tests = tests, type = 'tree', parts = { 'str' } },
-        { tests = tests, type = 'tree', parts = { 'num', 'num' } },
-        { tests = tests, type = 'tree', parts = { 'num', 'str' } },
-        { tests = tests, type = 'tree', parts = { 'str', 'num' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned', 'unsigned' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned', 'str' } },
+        { tests = tests, type = 'tree', parts = { 'str', 'unsigned' } },
         { tests = tests, type = 'tree', parts = { 'str', 'str' } }
     }
 end
 if engine == 'memtx' then
     workloads = {
-        { tests = tests, type = 'tree', parts = { 'num' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned' } },
         { tests = tests, type = 'tree', parts = { 'str' } },
-        { tests = tests, type = 'tree', parts = { 'num', 'num' } },
-        { tests = tests, type = 'tree', parts = { 'num', 'str' } },
-        { tests = tests, type = 'tree', parts = { 'str', 'num' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned', 'unsigned' } },
+        { tests = tests, type = 'tree', parts = { 'unsigned', 'str' } },
+        { tests = tests, type = 'tree', parts = { 'str', 'unsigned' } },
         { tests = tests, type = 'tree', parts = { 'str', 'str' } },
-        { tests = tests, type = 'hash', parts = { 'num' } },
+        { tests = tests, type = 'hash', parts = { 'unsigned' } },
         { tests = tests, type = 'hash', parts = { 'str' } },
-        { tests = tests, type = 'hash', parts = { 'num', 'num' } },
-        { tests = tests, type = 'hash', parts = { 'num', 'str' } },
-        { tests = tests, type = 'hash', parts = { 'str', 'num' } },
+        { tests = tests, type = 'hash', parts = { 'unsigned', 'unsigned' } },
+        { tests = tests, type = 'hash', parts = { 'unsigned', 'str' } },
+        { tests = tests, type = 'hash', parts = { 'str', 'unsigned' } },
         { tests = tests, type = 'hash', parts = { 'str', 'str' } },
     }
 end


### PR DESCRIPTION
field type 'num' is deprecated since Tarantool 1.7, please use 'unsigned' instead


Close tarantool/cbench#8


Example:

```
Benchmarking...
2022-02-14 20:47:37.562 [2562] wal/101/main xlog.c:1051 W> fallocate is not supported, proceeding without it
HASH unsigned
----------------------------------
replaces  : 1504.45     rps
selects   : 2419790.77  rps
selrepl   : 1532.78     rps
updates   : 1428.06     rps
deletes   : 1417.57     rps
----------------------------------
HASH unsigned
----------------------------------
replaces  : 1588.99     rps
selects   : 4839581.54  rps
selrepl   : 1394.54     rps
updates   : 1551.19     rps
deletes   : 1550.69     rps
----------------------------------
HASH str
----------------------------------
replaces  : 1522.58     rps
selects   : 691368.79   rps
selrepl   : 1591.04     rps
updates   : 1571.21     rps
deletes   : 1474.65     rps
----------------------------------
Done

```